### PR TITLE
Fix LMoP due to recent file renamed in DDB images

### DIFF
--- a/content/scene_info/lmop/lmop-10012-394-Map11CragmawHideout-player-scene.json
+++ b/content/scene_info/lmop/lmop-10012-394-Map11CragmawHideout-player-scene.json
@@ -1245,7 +1245,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/lmop/lmop4.jpg",
+            "originalLink": "ddb://image/lmop/map-1.1-Cragmaw-Hideout-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/lmop/lmop-10016-395-Map21Phandalin-player-scene.json
+++ b/content/scene_info/lmop/lmop-10016-395-Map21Phandalin-player-scene.json
@@ -272,7 +272,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "ddb://image/lmop/lmop1.jpg",
+            "originalLink": "ddb://image/lmop/map-2.1-Phandalin-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/lmop/lmop-10018-395-Map22RedbrandHideout-player-scene.json
+++ b/content/scene_info/lmop/lmop-10018-395-Map22RedbrandHideout-player-scene.json
@@ -1709,7 +1709,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/lmop/lmop5.jpg",
+            "originalLink": "ddb://image/lmop/map-2.2-Redbrand-Hideout-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/lmop/lmop-10024-396-Map31RuinsofThundertree-player-scene.json
+++ b/content/scene_info/lmop/lmop-10024-396-Map31RuinsofThundertree-player-scene.json
@@ -2588,7 +2588,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/lmop/lmop6.jpg",
+            "originalLink": "ddb://image/lmop/map-3.1-Ruins-of-Thundertree-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/lmop/lmop-10027-396-Map32CragmawCastle-player-scene.json
+++ b/content/scene_info/lmop/lmop-10027-396-Map32CragmawCastle-player-scene.json
@@ -2474,7 +2474,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/lmop/lmop3.jpg",
+            "originalLink": "ddb://image/lmop/map-3.2-Cragmaw-Castle-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/lmop/lmop-10033-397-Map41WaveEchoCave-player-scene.json
+++ b/content/scene_info/lmop/lmop-10033-397-Map41WaveEchoCave-player-scene.json
@@ -3688,7 +3688,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/lmop/lmop7.jpg",
+            "originalLink": "ddb://image/lmop/map-4.1-Wave-Echo-Cave-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {


### PR DESCRIPTION
LMoP version 15 renamed some of the `lmop{{index}}.jpg` files into `map-{{chapter}}-{{name}-player.jpg` filenames, which broke all the `originalLink`.
This should fix all of them in theory.