### PR TITLE
Fix DoSI background image links

### DIFF
--- a/content/scene_info/dosi/dosi-10006-1694-Map001stormwreckisle-player-scene.json
+++ b/content/scene_info/dosi/dosi-10006-1694-Map001stormwreckisle-player-scene.json
@@ -19,7 +19,7 @@
             "contentChunkId": "Map001stormwreckisle-player",
             "notes": [],
             "tokens": [],
-            "originalLink": "assets/map-0.01-stormwreck-isle-player.jpg",
+            "originalLink": "ddb://image/dosi/map-0.01-stormwreck-isle-player.jpg",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/dosi/dosi-10010-1692-Map101dragonsrest-player-scene.json
+++ b/content/scene_info/dosi/dosi-10010-1692-Map101dragonsrest-player-scene.json
@@ -165,7 +165,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-1.01-dragons-rest-player.jpg",
+            "originalLink": "ddb://image/dosi/map-1.01-dragons-rest-player.jpg",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/dosi/dosi-10014-1695-Map201seagrowcaves-player-scene.json
+++ b/content/scene_info/dosi/dosi-10014-1695-Map201seagrowcaves-player-scene.json
@@ -2300,7 +2300,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-2.01-seagrow-caves-player.jpg",
+            "originalLink": "ddb://image/dosi/map-2.01-seagrow-caves-player.jpg",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/dosi/dosi-10018-1691-Map301wreckofcompassrose-player-scene.json
+++ b/content/scene_info/dosi/dosi-10018-1691-Map301wreckofcompassrose-player-scene.json
@@ -793,7 +793,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-3.01-wreck-of-compass-rose-player.jpg",
+            "originalLink": "ddb://image/dosi/map-3.01-wreck-of-compass-rose-player.jpg",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/dosi/dosi-10022-1688-Map401clifftopobservatory-player-scene.json
+++ b/content/scene_info/dosi/dosi-10022-1688-Map401clifftopobservatory-player-scene.json
@@ -1113,7 +1113,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-4.01-clifftop-observatory-player.jpg",
+            "originalLink": "ddb://image/dosi/map-4.01-clifftop-observatory-player.jpg",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {


### PR DESCRIPTION
originalLink should be using ddb://image/dosi instead of assets/
Even as relative paths, the images aren't in an assets/ subfolder either