### PR TITLE
Fix map urls for moot, sotdq and tod

### DIFF
--- a/content/scene_info/moot/moot-10052-1040-Map42Agora-player-scene.json
+++ b/content/scene_info/moot/moot-10052-1040-Map42Agora-player-scene.json
@@ -320,7 +320,7 @@
             "contentChunkId": "Map42Agora-player",
             "notes": [],
             "tokens": [],
-            "originalLink": "assets/map-4.2-Asora-player.jpg",
+            "originalLink": "ddb://image/moot/map-4.2-Asora-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/moot/moot-10065-1040-Map415CoastalTemple-player-scene.json
+++ b/content/scene_info/moot/moot-10065-1040-Map415CoastalTemple-player-scene.json
@@ -11,7 +11,7 @@
             "contentChunkId": "Map415CoastalTemple-player",
             "notes": [],
             "tokens": [],
-            "originalLink": "assets/map-4.15-Coastal-Temple-player.jpg",
+            "originalLink": "ddb://image/moot/map-4.15-Coastal-Temple-player.jpg",
             "foundryVersion": "9.249",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10028-1711-Map301vogler-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10028-1711-Map301vogler-player-scene.json
@@ -479,7 +479,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-3.01-vogler-player.png",
+            "originalLink": "ddb://image/sotdq/map-3.01-vogler-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10032-1711-Map302battleofhighhill-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10032-1711-Map302battleofhighhill-player-scene.json
@@ -363,7 +363,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-3.02-battle-of-high-hill-player.png",
+            "originalLink": "ddb://image/sotdq/map-3.02-battle-of-high-hill-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10036-1711-Map303escapefromvogler-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10036-1711-Map303escapefromvogler-player-scene.json
@@ -708,7 +708,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-3.03-escape-from-vogler-player.png",
+            "originalLink": "ddb://image/sotdq/map-3.03-escape-from-vogler-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10039-1705-Map401kalaman-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10039-1705-Map401kalaman-player-scene.json
@@ -474,7 +474,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-4.01-kalaman-player.png",
+            "originalLink": "ddb://image/sotdq/map-4.01-kalaman-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10046-1705-Map402wheelhouseoutpost-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10046-1705-Map402wheelhouseoutpost-player-scene.json
@@ -1779,7 +1779,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-4.02-wheelhouse-outpost-player.png",
+            "originalLink": "ddb://image/sotdq/map-4.02-wheelhouse-outpost-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10047-1705-Map403retreatfromsteelsprings-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10047-1705-Map403retreatfromsteelsprings-player-scene.json
@@ -771,7 +771,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-4.03-retreat-from-steel-springs-player.png",
+            "originalLink": "ddb://image/sotdq/map-4.03-retreat-from-steel-springs-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10050-1705-Map404raidedcatacombs-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10050-1705-Map404raidedcatacombs-player-scene.json
@@ -549,7 +549,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-4.04-raided-catacombs-player.png",
+            "originalLink": "ddb://image/sotdq/map-4.04-raided-catacombs-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10054-1709-Map501kalamanandnorthernwastes-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10054-1709-Map501kalamanandnorthernwastes-player-scene.json
@@ -488,7 +488,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-5.01-kalaman-and-northern-wastes-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.01-kalaman-and-northern-wastes-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10058-1699-Map601pathofmemories-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10058-1699-Map601pathofmemories-player-scene.json
@@ -939,7 +939,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-6.01-path-of-memories-player.png",
+            "originalLink": "ddb://image/sotdq/map-6.01-path-of-memories-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10058-1709-Map502bluephoenixshrine-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10058-1709-Map502bluephoenixshrine-player-scene.json
@@ -543,7 +543,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.02-blue-phoenix-shrine-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.02-blue-phoenix-shrine-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10060-1709-Map503sunwardfortress-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10060-1709-Map503sunwardfortress-player-scene.json
@@ -910,7 +910,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.03-sunward-fortress-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.03-sunward-fortress-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10061-1699-Map602cityoflostnames-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10061-1699-Map602cityoflostnames-player-scene.json
@@ -200,7 +200,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-6.02-city-of-last-names-player.png",
+            "originalLink": "ddb://image/sotdq/map-6.02-city-of-last-names-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10063-1699-Map603occupiedmansion-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10063-1699-Map603occupiedmansion-player-scene.json
@@ -2196,7 +2196,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-6.03-occupied-mansion-player.png",
+            "originalLink": "ddb://image/sotdq/map-6.03-occupied-mansion-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10063-1709-Map504wakenreth-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10063-1709-Map504wakenreth-player-scene.json
@@ -376,7 +376,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.04-wakenreth-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.04-wakenreth-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10064-1699-Map604templeofpaladine-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10064-1699-Map604templeofpaladine-player-scene.json
@@ -705,7 +705,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-6.04-temple-of-paladine-player.png",
+            "originalLink": "ddb://image/sotdq/map-6.04-temple-of-paladine-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10065-1699-Map605thresholdoftheheavens-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10065-1699-Map605thresholdoftheheavens-player-scene.json
@@ -1722,7 +1722,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-6.05-threshold-of-the-heavens-player.png",
+            "originalLink": "ddb://image/sotdq/map-6.05-threshold-of-the-heavens-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10066-1709-Map505bluemawcave-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10066-1709-Map505bluemawcave-player-scene.json
@@ -1013,7 +1013,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.05-bluemaw-cave-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.05-bluemaw-cave-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10069-1709-Map506heartshollow-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10069-1709-Map506heartshollow-player-scene.json
@@ -238,7 +238,7 @@
                 }
             ],
             "tokens": [],
-            "originalLink": "assets/map-5.06-hearts-hollow-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.06-hearts-hollow-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10071-1709-Map507campcarrionclay-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10071-1709-Map507campcarrionclay-player-scene.json
@@ -1958,7 +1958,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.07-camp-carrionclay-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.07-camp-carrionclay-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10073-1709-Map508attackonwindsend-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10073-1709-Map508attackonwindsend-player-scene.json
@@ -567,7 +567,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-5.08-attack-on-winds-end-player.png",
+            "originalLink": "ddb://image/sotdq/map-5.08-attack-on-winds-end-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10074-1707-Map701assaultonhawkersgrove-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10074-1707-Map701assaultonhawkersgrove-player-scene.json
@@ -574,7 +574,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.01-assault-on-hawkers-grove-player.png",
+            "originalLink": "ddb://image/sotdq/map-7.01-assault-on-hawkers-grove-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10075-1707-Map702flyingcitadelsublevels-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10075-1707-Map702flyingcitadelsublevels-player-scene.json
@@ -2572,7 +2572,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.02-flying-citadel-sublevels-player.png",
+            "originalLink": "ddb://image/sotdq/map-7.02-flying-citadel-sublevels-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10077-1707-Map705clashoffallenflames-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10077-1707-Map705clashoffallenflames-player-scene.json
@@ -217,7 +217,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.05-clash-of-fallen-flames-player.png",
+            "originalLink": "ddb://image/sotdq/map-7.05-clash-of-fallen-flames-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10080-1707-Map703bastionoftakhisis-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10080-1707-Map703bastionoftakhisis-player-scene.json
@@ -514,7 +514,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.03-bastion-of-takhisis-player.png",
+            "originalLink": "ddb://image/sotdq/map-7.03-bastion-of-takhisis-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10084-1707-Map704flyingcitadelsurface-player-scene.json
+++ b/content/scene_info/sotdq/sotdq-10084-1707-Map704flyingcitadelsurface-player-scene.json
@@ -327,7 +327,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.04-flying-citadel-surface-player.png",
+            "originalLink": "ddb://image/sotdq/map-7.04-flying-citadel-surface-player.png",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10088-1703-KalamanNorthernWastes-unlabeled-scene.json
+++ b/content/scene_info/sotdq/sotdq-10088-1703-KalamanNorthernWastes-unlabeled-scene.json
@@ -18,7 +18,7 @@
             "contentChunkId": "KalamanNorthernWastes-unlabeled",
             "notes": [],
             "tokens": [],
-            "originalLink": "assets/map-12.01-kalaman-northern-wastes-player.png",
+            "originalLink": "ddb://image/sotdq/map-12.01-kalaman-northern-wastes-player.png",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/sotdq/sotdq-10090-1703-TheContinentofAnsalon-unlabeled-scene.json
+++ b/content/scene_info/sotdq/sotdq-10090-1703-TheContinentofAnsalon-unlabeled-scene.json
@@ -18,7 +18,7 @@
             "contentChunkId": "TheContinentofAnsalon-unlabeled",
             "notes": [],
             "tokens": [],
-            "originalLink": "assets/map-12.02-ansalon-continent-player.png",
+            "originalLink": "ddb://image/sotdq/map-12.02-ansalon-continent-player.png",
             "foundryVersion": "10.290",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10013-1734-Map11Greenest-player-scene.json
+++ b/content/scene_info/tod/tod-10013-1734-Map11Greenest-player-scene.json
@@ -3656,7 +3656,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-1.01-greenest-player.jpg",
+            "originalLink": "ddb://image/tod/map-1.01-greenest-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10018-1742-Map21RaiderCamp-player-scene.json
+++ b/content/scene_info/tod/tod-10018-1742-Map21RaiderCamp-player-scene.json
@@ -1129,7 +1129,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-2.01-raider-camp-player.jpg",
+            "originalLink": "ddb://image/tod/map-2.01-raider-camp-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10022-1733-Map31DragonHatchery-player-scene.json
+++ b/content/scene_info/tod/tod-10022-1733-Map31DragonHatchery-player-scene.json
@@ -2583,7 +2583,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-3.01-dragon-hatchery-player.jpg",
+            "originalLink": "ddb://image/tod/map-3.01-dragon-hatchery-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10034-1728-Map51CarnathRoadhouse-player-scene.json
+++ b/content/scene_info/tod/tod-10034-1728-Map51CarnathRoadhouse-player-scene.json
@@ -485,7 +485,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-5.01-carnath-roadhouse-player.jpg",
+            "originalLink": "ddb://image/tod/map-5.01-carnath-roadhouse-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10042-1726-Map61CastleNaerytarGroundLevel-player-scene.json
+++ b/content/scene_info/tod/tod-10042-1726-Map61CastleNaerytarGroundLevel-player-scene.json
@@ -6754,7 +6754,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-6.01-castle-naerytar-ground-player.jpg",
+            "originalLink": "ddb://image/tod/map-6.01-castle-naerytar-ground-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10045-1726-Map62CastleNaerytarLevel2-player-scene.json
+++ b/content/scene_info/tod/tod-10045-1726-Map62CastleNaerytarLevel2-player-scene.json
@@ -2872,7 +2872,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/assets/map-6.02-castle-naerytar-2nd-floor-player.jpg",
+            "originalLink": "ddb://image/tod/map-6.02-castle-naerytar-2nd-floor-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10046-1726-Map63CastleNaerytarLevel3-player-scene.json
+++ b/content/scene_info/tod/tod-10046-1726-Map63CastleNaerytarLevel3-player-scene.json
@@ -1581,7 +1581,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-6.03-castle-naerytar-level-3-player.jpg",
+            "originalLink": "ddb://image/tod/map-6.03-castle-naerytar-level-3-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10047-1726-Map64CastleNaerytarDungeon-player-scene.json
+++ b/content/scene_info/tod/tod-10047-1726-Map64CastleNaerytarDungeon-player-scene.json
@@ -2213,7 +2213,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-6.04-castle-naerytar-dungeon-player.jpg",
+            "originalLink": "ddb://image/tod/map-6.04-castle-naerytar-dungeon-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10054-1735-Map71HuntingLodgeGroundFloor-player-scene.json
+++ b/content/scene_info/tod/tod-10054-1735-Map71HuntingLodgeGroundFloor-player-scene.json
@@ -2709,7 +2709,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-7.01-hunting-lodge-ground-floor-player.jpg",
+            "originalLink": "ddb://image/tod/map-7.01-hunting-lodge-ground-floor-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10055-1735-Map72HuntingLodgeUpperFloor-player-scene.json
+++ b/content/scene_info/tod/tod-10055-1735-Map72HuntingLodgeUpperFloor-player-scene.json
@@ -1822,7 +1822,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-7.02-hunting-lodge-upper-floor-player.jpg",
+            "originalLink": "ddb://image/tod/map-7.02-hunting-lodge-upper-floor-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10057-1725-Map81Parnast-player-scene.json
+++ b/content/scene_info/tod/tod-10057-1725-Map81Parnast-player-scene.json
@@ -989,7 +989,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-8.01-parnast-player.jpg",
+            "originalLink": "ddb://image/tod/map-8.01-parnast-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10058-1725-Map82SkyreachCastle-player-scene.json
+++ b/content/scene_info/tod/tod-10058-1725-Map82SkyreachCastle-player-scene.json
@@ -3000,7 +3000,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-8.02-skyreach-castle-player.jpg",
+            "originalLink": "ddb://image/tod/map-8.02-skyreach-castle-player.jpg",
             "foundryVersion": "0.8.9",
             "tiles": [
                 {

--- a/content/scene_info/tod/tod-10073-1744-Map101ArauthatorsIcebergOyaviggatonArauthatorsLair-player-scene.json
+++ b/content/scene_info/tod/tod-10073-1744-Map101ArauthatorsIcebergOyaviggatonArauthatorsLair-player-scene.json
@@ -2498,7 +2498,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-10.01-Oyaviggaton-player.jpg",
+            "originalLink": "ddb://image/tod/map-10.01-Oyaviggaton-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10081-1732-Map111TombofDiderius-player-scene.json
+++ b/content/scene_info/tod/tod-10081-1732-Map111TombofDiderius-player-scene.json
@@ -3790,7 +3790,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-11.01-tomb-of-diderius-player.jpg",
+            "originalLink": "ddb://image/tod/map-11.01-tomb-of-diderius-player.jpg",
             "foundryVersion": "0.8.9",
             "tiles": [
                 {

--- a/content/scene_info/tod/tod-10086-1732-Map32NeronvainsStronghold-player-scene.json
+++ b/content/scene_info/tod/tod-10086-1732-Map32NeronvainsStronghold-player-scene.json
@@ -1465,7 +1465,7 @@
                     }
                 }
             ],
-            "originalLink": "assets/map-11.02-neronvains-stronghold-player.jpg",
+            "originalLink": "ddb://image/tod/map-11.02-neronvains-stronghold-player.jpg",
             "foundryVersion": "9.238",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10102-1746-Map151XonthalsTower-player-scene.json
+++ b/content/scene_info/tod/tod-10102-1746-Map151XonthalsTower-player-scene.json
@@ -3351,7 +3351,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-14.01-xonthals-tower-player.jpg",
+            "originalLink": "ddb://image/tod/map-14.01-xonthals-tower-player.jpg",
             "foundryVersion": "9.238",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10116-1745-Map171TheWellofDragons-player-scene.json
+++ b/content/scene_info/tod/tod-10116-1745-Map171TheWellofDragons-player-scene.json
@@ -4909,7 +4909,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-16.01-well-of-dragons-player.jpg",
+            "originalLink": "ddb://image/tod/map-16.01-well-of-dragons-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {

--- a/content/scene_info/tod/tod-10117-1745-Map172TiamatsTemple-player-scene.json
+++ b/content/scene_info/tod/tod-10117-1745-Map172TiamatsTemple-player-scene.json
@@ -712,7 +712,7 @@
                     "actorData": {}
                 }
             ],
-            "originalLink": "assets/map-16.02-tiamats-temple-player.jpg",
+            "originalLink": "ddb://image/tod/map-16.02-tiamats-temple-player.jpg",
             "foundryVersion": "0.8.9",
             "versions": {
                 "ddbMetaData": {


### PR DESCRIPTION
More map urls using an `assets/` prefix which breaks images for moot, sodtq and tod books.
This is similar to #5 which changes those to `ddb://image/` urls