### PR TITLE
Set image url for hotdq maps

### DIFF
--- a/content/scene_info/hotdq/hotdq-103058-436-ddb-missing-hotdq-103058-scene.json
+++ b/content/scene_info/hotdq/hotdq-103058-436-ddb-missing-hotdq-103058-scene.json
@@ -1330,6 +1330,7 @@
     ],
     "name": "Skyreach Castle - Ice Tunnels",
     "navName": "Skyreach Castle - Ice Tunnels",
+    "originalLink": "ddb://image/hotdq/map-8-2-skyreach-player.jpg",
     "padding": 0.25,
     "shiftX": 21,
     "shiftY": 54,

--- a/content/scene_info/hotdq/hotdq-103059-436-ddb-missing-hotdq-103059-scene.json
+++ b/content/scene_info/hotdq/hotdq-103059-436-ddb-missing-hotdq-103059-scene.json
@@ -3909,6 +3909,7 @@
     ],
     "name": "Skyreach Castle - Lower Courtyard",
     "navName": "Skyreach Castle - Lower Courtyard",
+    "originalLink": "ddb://image/hotdq/map-8-2-skyreach-player.jpg",
     "padding": 0.25,
     "shiftX": -29,
     "shiftY": 90,

--- a/content/scene_info/hotdq/hotdq-11019-429-0ae8c597-7701-4752-9f67-7918d528da2d-scene.json
+++ b/content/scene_info/hotdq/hotdq-11019-429-0ae8c597-7701-4752-9f67-7918d528da2d-scene.json
@@ -1878,6 +1878,7 @@
     ],
     "name": "Raider Camp",
     "navName": "Raider Camp",
+    "originalLink": "ddb://image/hotdq/hotdq/map-2-1-raider-camp-player.jpg",
     "padding": 0.25,
     "shiftX": 0,
     "shiftY": 0,

--- a/content/scene_info/hotdq/hotdq-13023-431-b17a287b-8c7a-481a-b839-539a575e86d5-scene.json
+++ b/content/scene_info/hotdq/hotdq-13023-431-b17a287b-8c7a-481a-b839-539a575e86d5-scene.json
@@ -2999,6 +2999,7 @@
     ],
     "name": "Dragon Hatchery",
     "navName": "Dragon Hatchery",
+    "originalLink": "ddb://image/hotdq/map-3-1-dragon-hatchery-player.jpg",
     "padding": 0.25,
     "shiftX": 44,
     "shiftY": 10,


### PR DESCRIPTION
The `originalLink` field was missing in these 4 scenes.