### PR TITLE
Fix `thsot` map player img link

### DIFF
--- a/content/scene_info/thsot/thsot-10004-386-Map31TheHiddenShrineofTamoachan-player-scene.json
+++ b/content/scene_info/thsot/thsot-10004-386-Map31TheHiddenShrineofTamoachan-player-scene.json
@@ -8785,7 +8785,7 @@
                     }
                 }
             ],
-            "originalLink": "ddb://image/thsot/hsotplayer.jpg",
+            "originalLink": "ddb://image/thsot/map-3.1-hidden-shrine-player.jpg",
             "foundryVersion": "10.291",
             "versions": {
                 "ddbMetaData": {


### PR DESCRIPTION
The `originalLink` for the `thsot` map appears to be incorrect, the image URL may have been updated. This change updates `originalLink` in the metadata